### PR TITLE
feat: add two samples from ISPY2 dataset

### DIFF
--- a/nbia.yaml
+++ b/nbia.yaml
@@ -45,3 +45,7 @@ datasets:
     patients:
       - Adrenal_Ki67_Seg_002
       - Adrenal_Ki67_Seg_004
+  ISPY2:
+    patients:
+      - ISPY2-102011 # 39 series
+      - ISPY2-111038 # 32 series


### PR DESCRIPTION
Includes MRI and SEG, 3GB of data, 71 series in total for both
[series-data1739548936015.csv](https://github.com/user-attachments/files/18801827/series-data1739548936015.csv)
